### PR TITLE
GET /article/{article-id} APIのレスポンス形式変更

### DIFF
--- a/internal/presentation/handler/article_get.go
+++ b/internal/presentation/handler/article_get.go
@@ -43,12 +43,14 @@ func (a *ArticleGetHandler) ArticleGet(c *gin.Context, articleId string) {
 		return
 	}
 
-	c.JSON(http.StatusOK, &openapi.Article{
-		Id:          useCaseOutput.ID,
-		UpdatedAt:   &useCaseOutput.UpdatedAt,
-		PublishedAt: useCaseOutput.PublishedAt,
-		Title:       useCaseOutput.Title,
-		Contents:    &useCaseOutput.Contents,
-		Tags:        useCaseOutput.Tags,
+	c.JSON(http.StatusOK, &openapi.ArticleGetResponseBody{
+		Article: openapi.Article{
+			Id:          useCaseOutput.ID,
+			UpdatedAt:   &useCaseOutput.UpdatedAt,
+			PublishedAt: useCaseOutput.PublishedAt,
+			Title:       useCaseOutput.Title,
+			Contents:    &useCaseOutput.Contents,
+			Tags:        useCaseOutput.Tags,
+		},
 	})
 }

--- a/test/integration/article_get_test.go
+++ b/test/integration/article_get_test.go
@@ -129,16 +129,18 @@ func TestArticleGet(t *testing.T) {
 				})
 
 				// Assert
-				wantResponseBody := openapi.Article{
-					Id:          tt.testArticleInputs[0].ID,
-					UpdatedAt:   &tt.testArticleInputs[0].UpdatedAt,
-					PublishedAt: tt.testArticleInputs[0].PublishedAt,
-					Title:       tt.testArticleInputs[0].Title,
-					Contents:    &tt.testArticleInputs[0].Contents,
-					Tags:        tt.testArticleInputs[0].Tags,
+				wantResponseBody := openapi.ArticleGetResponseBody{
+					Article: openapi.Article{
+						Id:          tt.testArticleInputs[0].ID,
+						UpdatedAt:   &tt.testArticleInputs[0].UpdatedAt,
+						PublishedAt: tt.testArticleInputs[0].PublishedAt,
+						Title:       tt.testArticleInputs[0].Title,
+						Contents:    &tt.testArticleInputs[0].Contents,
+						Tags:        tt.testArticleInputs[0].Tags,
+					},
 				}
 
-				var decodedGotResponseBody openapi.Article
+				var decodedGotResponseBody openapi.ArticleGetResponseBody
 				err = json.NewDecoder(gotResponse.Body).Decode(&decodedGotResponseBody)
 				require.NoError(t, err)
 


### PR DESCRIPTION
# issue
<!-- Link to related issue -->

# overview
<!-- Describe what this PR does -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- リファクタリング
  - 記事取得APIのJSONレスポンス形式を変更。記事データはラップされたオブジェクト内のフィールドに格納されます。既存クライアントはパース処理の更新が必要です。

- テスト
  - 変更後のレスポンス形式に合わせて統合テストを更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->