### PR TITLE
OpenAPIの型を細分化

### DIFF
--- a/internal/presentation/handler/article_get.go
+++ b/internal/presentation/handler/article_get.go
@@ -44,12 +44,12 @@ func (a *ArticleGetHandler) ArticleGet(c *gin.Context, articleId string) {
 	}
 
 	c.JSON(http.StatusOK, &openapi.ArticleGetResponseBody{
-		Article: openapi.Article{
+		Article: openapi.ArticleDetail{
 			Id:          useCaseOutput.ID,
-			UpdatedAt:   &useCaseOutput.UpdatedAt,
+			UpdatedAt:   useCaseOutput.UpdatedAt,
 			PublishedAt: useCaseOutput.PublishedAt,
 			Title:       useCaseOutput.Title,
-			Contents:    &useCaseOutput.Contents,
+			Contents:    useCaseOutput.Contents,
 			Tags:        useCaseOutput.Tags,
 		},
 	})

--- a/internal/presentation/handler/articles_get.go
+++ b/internal/presentation/handler/articles_get.go
@@ -37,9 +37,9 @@ func (a *ArticlesGetHandler) ArticlesGet(c *gin.Context, params openapi.Articles
 	}
 
 	// レスポンスボディの型へ変換
-	var articles []openapi.Article
+	var articles []openapi.ArticleSummary
 	for _, article := range useCaseOutput.Articles {
-		articles = append(articles, openapi.Article{
+		articles = append(articles, openapi.ArticleSummary{
 			Id:          article.ID,
 			PublishedAt: article.PublishedAt,
 			Title:       article.Title,

--- a/internal/presentation/openapi/api.yaml
+++ b/internal/presentation/openapi/api.yaml
@@ -113,6 +113,7 @@ components:
       description: リクエストID（UUIDv4形式）
       example: "123e4567-e89b-12d3-a456-426614174000"
 
+    # APIレスポンス
     ArticlesGetResponseBody:
       type: object
       required:
@@ -121,16 +122,17 @@ components:
         articles:
           type: array
           items:
-            $ref: '#/components/schemas/Article'
+            $ref: '#/components/schemas/ArticleSummary'
     ArticleGetResponseBody:
       type: object
       required:
         - article
       properties:
         article:
-          $ref: '#/components/schemas/Article'
+          $ref: '#/components/schemas/ArticleDetail'
 
-    Article:
+    # Article
+    ArticleSummary:
       type: object
       required:
         - id
@@ -139,39 +141,72 @@ components:
         - tags
       properties:
         id:
-          type: string
-          description: 記事ID（ハイフン無しのUUIDv4形式）
-          example: "123e4567e89b12d3a456426655440000"
-        updated_at:
-          type: string
-          format: date-time
-          description: 更新日時（UTC）
-          example: "2025-01-15T12:00:00Z"
+          $ref: '#/components/schemas/ArticleId'
         published_at:
-          type: string
-          format: date-time
-          description: 公開日時（UTC）
-          example: "2025-01-15T12:00:00Z"
+          $ref: '#/components/schemas/ArticlePublishedAt'
         title:
-          type: string
-          description: 記事タイトル
-          example: "Go言語入門"
-        contents:
-          type: string
-          description: 記事内容（マークダウン形式）
-          example: |
-            # 入門チャプター
-            - 標準出力
-            - 変数と定数
-            - 条件分岐
-            - ループ
+          $ref: '#/components/schemas/ArticleTitle'
         tags:
-          type: array
-          items:
-            type: string
-          description: タグ
-          example: ["Go", "JavaScript", "AWS"]
+          $ref: '#/components/schemas/ArticleTags'
+    ArticleDetail:
+      type: object
+      required:
+        - id
+        - published_at
+        - updated_at
+        - title
+        - contents
+        - tags
+      properties:
+        id:
+          $ref: '#/components/schemas/ArticleId'
+        published_at:
+          $ref: '#/components/schemas/ArticlePublishedAt'
+        updated_at:
+          $ref: '#/components/schemas/ArticleUpdatedAt'
+        title:
+          $ref: '#/components/schemas/ArticleTitle'
+        contents:
+          $ref: '#/components/schemas/ArticleContents'
+        tags:
+          $ref: '#/components/schemas/ArticleTags'
 
+    # Articleプロパティ
+    ArticleId:
+      type: string
+      description: 記事ID（ハイフン無しのUUIDv4形式）
+      example: "123e4567e89b12d3a456426655440000"
+    ArticleTitle:
+      type: string
+      description: 記事タイトル
+      example: "Go言語入門"
+    ArticleContents:
+      type: string
+      description: 記事内容（マークダウン形式）
+      example: |
+        # 入門チャプター
+        - 標準出力
+        - 変数と定数
+        - 条件分岐
+        - ループ
+    ArticlePublishedAt:
+      type: string
+      format: date-time
+      description: 公開日時（UTC）
+      example: "2025-01-15T12:00:00Z"
+    ArticleUpdatedAt:
+      type: string
+      format: date-time
+      description: 更新日時（UTC）
+      example: "2025-01-15T12:00:00Z"
+    ArticleTags:
+      type: array
+      items:
+        type: string
+      description: タグ
+      example: [ "Go", "JavaScript", "AWS" ]
+
+    # エラー定義
     Error:
       type: object
       required:

--- a/internal/presentation/openapi/types.gen.go
+++ b/internal/presentation/openapi/types.gen.go
@@ -13,35 +13,68 @@ const (
 	NotFound            ErrorCode = "not_found"
 )
 
-// Article defines model for Article.
-type Article struct {
+// ArticleContents 記事内容（マークダウン形式）
+type ArticleContents = string
+
+// ArticleDetail defines model for ArticleDetail.
+type ArticleDetail struct {
 	// Contents 記事内容（マークダウン形式）
-	Contents *string `json:"contents,omitempty"`
+	Contents ArticleContents `json:"contents"`
 
 	// Id 記事ID（ハイフン無しのUUIDv4形式）
-	Id string `json:"id"`
+	Id ArticleId `json:"id"`
 
 	// PublishedAt 公開日時（UTC）
-	PublishedAt time.Time `json:"published_at"`
+	PublishedAt ArticlePublishedAt `json:"published_at"`
 
 	// Tags タグ
-	Tags []string `json:"tags"`
+	Tags ArticleTags `json:"tags"`
 
 	// Title 記事タイトル
-	Title string `json:"title"`
+	Title ArticleTitle `json:"title"`
 
 	// UpdatedAt 更新日時（UTC）
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	UpdatedAt ArticleUpdatedAt `json:"updated_at"`
 }
 
 // ArticleGetResponseBody defines model for ArticleGetResponseBody.
 type ArticleGetResponseBody struct {
-	Article Article `json:"article"`
+	Article ArticleDetail `json:"article"`
 }
+
+// ArticleId 記事ID（ハイフン無しのUUIDv4形式）
+type ArticleId = string
+
+// ArticlePublishedAt 公開日時（UTC）
+type ArticlePublishedAt = time.Time
+
+// ArticleSummary defines model for ArticleSummary.
+type ArticleSummary struct {
+	// Id 記事ID（ハイフン無しのUUIDv4形式）
+	Id ArticleId `json:"id"`
+
+	// PublishedAt 公開日時（UTC）
+	PublishedAt ArticlePublishedAt `json:"published_at"`
+
+	// Tags タグ
+	Tags ArticleTags `json:"tags"`
+
+	// Title 記事タイトル
+	Title ArticleTitle `json:"title"`
+}
+
+// ArticleTags タグ
+type ArticleTags = []string
+
+// ArticleTitle 記事タイトル
+type ArticleTitle = string
+
+// ArticleUpdatedAt 更新日時（UTC）
+type ArticleUpdatedAt = time.Time
 
 // ArticlesGetResponseBody defines model for ArticlesGetResponseBody.
 type ArticlesGetResponseBody struct {
-	Articles []Article `json:"articles"`
+	Articles []ArticleSummary `json:"articles"`
 }
 
 // Error defines model for Error.

--- a/test/integration/article_get_test.go
+++ b/test/integration/article_get_test.go
@@ -130,12 +130,12 @@ func TestArticleGet(t *testing.T) {
 
 				// Assert
 				wantResponseBody := openapi.ArticleGetResponseBody{
-					Article: openapi.Article{
+					Article: openapi.ArticleDetail{
 						Id:          tt.testArticleInputs[0].ID,
-						UpdatedAt:   &tt.testArticleInputs[0].UpdatedAt,
+						UpdatedAt:   tt.testArticleInputs[0].UpdatedAt,
 						PublishedAt: tt.testArticleInputs[0].PublishedAt,
 						Title:       tt.testArticleInputs[0].Title,
-						Contents:    &tt.testArticleInputs[0].Contents,
+						Contents:    tt.testArticleInputs[0].Contents,
 						Tags:        tt.testArticleInputs[0].Tags,
 					},
 				}

--- a/test/integration/articles_get_test.go
+++ b/test/integration/articles_get_test.go
@@ -95,7 +95,7 @@ func TestArticlesGet(t *testing.T) {
 
 				// テストデータ作成
 				var articles []entity.Article
-				var wantArticles []openapi.Article
+				var wantArticles []openapi.ArticleSummary
 				for _, testArticleInput := range tt.testArticleInputs {
 					// DynamoDB登録用のEntity作成
 					article, err := entity.NewArticle(&testArticleInput)
@@ -107,7 +107,7 @@ func TestArticlesGet(t *testing.T) {
 					if testArticleInput.Status != enum.StatusPublish.String() {
 						continue
 					}
-					wantArticles = append(wantArticles, openapi.Article{
+					wantArticles = append(wantArticles, openapi.ArticleSummary{
 						Id:          testArticleInput.ID,
 						PublishedAt: testArticleInput.PublishedAt,
 						Title:       testArticleInput.Title,


### PR DESCRIPTION
# issue
<!-- Link to related issue -->

# overview
<!-- Describe what this PR does -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * 記事APIを「一覧＝ArticleSummary」「詳細＝ArticleDetail」に分離。一覧は id/published_at/title/tags を返却、詳細は id/published_at/updated_at/title/contents/tags を返却。詳細の updated_at と contents は必須化。API利用時は新スキーマへ移行が必要です。
* ドキュメント
  * 公開スキーマを更新し、要約/詳細の定義を追加。標準化されたエラー構造（code, message, details）を公開しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->