### PR TITLE
change dependabot conf

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,9 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "monthly"
-      time: "20:00"
+      interval: "weekly"
+      day: "friday"
+      time: "21:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 20
     cooldown:
@@ -21,8 +22,9 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "monthly"
-      time: "20:00"
+      interval: "weekly"
+      day: "friday"
+      time: "21:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 20
     cooldown:
@@ -38,8 +40,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
-      time: "20:00"
+      interval: "weekly"
+      day: "friday"
+      time: "21:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 20
     cooldown:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* チョア
  * 依存関係の自動更新スケジュールを月次20:00から毎週金曜21:00（Asia/Tokyo）へ変更し、7日間のクールダウンを追加。対象はGoモジュール、Docker、GitHub Actions。タイムゾーン、同時PR上限、レビュアー、アサイン、ラベルは変更なし。ユーザー向け機能への影響はありませんが、更新の頻度と安定性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->