### PR TITLE
refactor: log_type切替を呼び出し元の明示優先方式に変更

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ issues:
 linters:
   enable:
     - bodyclose     # httpレスポンスのclose
-    - dupl          # 重複コード
     - errcheck      # エラーハンドリング
     - errorlint     # error型関連
     - exhaustive    # 網羅性
@@ -34,6 +33,7 @@ linters:
     - unused        # 未使用コード
     - whitespace    # if,for前後の不要な改行
   disable:
+    - dupl          # 重複コード
     - funlen        # 関数の行数
   settings:
     errcheck:

--- a/internal/common/logger/constant.go
+++ b/internal/common/logger/constant.go
@@ -1,0 +1,8 @@
+package logger
+
+type LogType string
+
+const (
+	LogTypeApp    LogType = "app_log"
+	LogTypeAccess LogType = "access_log"
+)

--- a/internal/common/logger/context.go
+++ b/internal/common/logger/context.go
@@ -21,11 +21,17 @@ func (l *LogContext) Set(key string, value any) {
 	l.attributes[key] = value
 }
 
-// ForEach 全属性を列挙する。読み出し中は書き込みがブロックされ、列挙はatomic snapshotとなる
+// ForEach 全属性を列挙する。列挙はatomic snapshotとなる
 func (l *LogContext) ForEach(fn func(key string, value any)) {
+	// コールバック内でSetが呼ばれても自己デッドロックしないためにattributesをコピーする
 	l.mutex.RLock()
-	defer l.mutex.RUnlock()
+	attributes := make(map[string]any, len(l.attributes))
 	for key, value := range l.attributes {
+		attributes[key] = value
+	}
+	l.mutex.RUnlock()
+
+	for key, value := range attributes {
 		fn(key, value)
 	}
 }

--- a/internal/common/logger/context.go
+++ b/internal/common/logger/context.go
@@ -5,33 +5,49 @@ import (
 	"sync"
 )
 
-func NewLogContextMap() *sync.Map {
-	return &sync.Map{}
+type LogContext struct {
+	mutex      sync.RWMutex
+	attributes map[string]any
 }
 
-type logContextMapKey struct{}
-
-// WithLogContextMap LogContextMapをセットしたcontextを返す
-func WithLogContextMap(ctx context.Context, logContextMap *sync.Map) context.Context {
-	return context.WithValue(ctx, logContextMapKey{}, logContextMap)
+func NewLogContext() *LogContext {
+	return &LogContext{attributes: map[string]any{}}
 }
 
-// LogContextMapFromContext contextからLogContextMapを取り出す
-func LogContextMapFromContext(ctx context.Context) (*sync.Map, bool) {
-	logContextMap, ok := ctx.Value(logContextMapKey{}).(*sync.Map)
-	return logContextMap, ok
+// Set 属性を追加・更新する
+func (l *LogContext) Set(key string, value any) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.attributes[key] = value
 }
 
-type LogType string
+// ForEach 全属性を列挙する。読み出し中は書き込みがブロックされ、列挙はatomic snapshotとなる
+func (l *LogContext) ForEach(fn func(key string, value any)) {
+	l.mutex.RLock()
+	defer l.mutex.RUnlock()
+	for key, value := range l.attributes {
+		fn(key, value)
+	}
+}
 
-const (
-	LogTypeApp    LogType = "app_log"
-	LogTypeAccess LogType = "access_log"
-)
+type logContextKey struct{}
 
-func ChangeLogType(ctx context.Context, logType LogType) {
-	logContextMap, ok := LogContextMapFromContext(ctx)
+// WithLogContext LogContextをセットしたcontextを返す
+func WithLogContext(ctx context.Context, logContext *LogContext) context.Context {
+	return context.WithValue(ctx, logContextKey{}, logContext)
+}
+
+// LogContextFromContext contextからLogContextを取り出す
+func LogContextFromContext(ctx context.Context) (*LogContext, bool) {
+	logContext, ok := ctx.Value(logContextKey{}).(*LogContext)
+	return logContext, ok
+}
+
+// SetLogContextAttribute contextに紐づくLogContextに属性を追加する。
+// LogContextが未設定の場合は何もしない（middleware外で呼ばれた場合の想定）
+func SetLogContextAttribute(ctx context.Context, key string, value any) {
+	logContext, ok := LogContextFromContext(ctx)
 	if ok {
-		logContextMap.Store("log_type", logType)
+		logContext.Set(key, value)
 	}
 }

--- a/internal/common/logger/custom.go
+++ b/internal/common/logger/custom.go
@@ -15,20 +15,30 @@ func NewCustomLogHandler(handler slog.Handler) *CustomLogHandler {
 	}
 }
 
-// Handle contextにセットされたLogContextMapからログ出力フィールドを追加する
+// Handle contextにセットされたLogContextからログ出力フィールドを追加する
 func (h *CustomLogHandler) Handle(ctx context.Context, r slog.Record) error { //nolint:gocritic // slogのinterface仕様なので第2引数はポインタ型にできない
-	logContextMap, ok := LogContextMapFromContext(ctx)
+	logContext, ok := LogContextFromContext(ctx)
 	if !ok {
 		return h.Handler.Handle(ctx, r)
 	}
 
 	r = r.Clone()
-	for key, value := range logContextMap.Range {
-		keyStr, ok2 := key.(string)
-		if ok2 {
-			r.AddAttrs(slog.Any(keyStr, value))
+
+	// 呼び出し元で明示的にセットされたキーを記録し、LogContextに同名キーがある場合はスキップする
+	// （呼び出し元の値がLogContextより優先される）
+	existing := make(map[string]struct{})
+	r.Attrs(func(a slog.Attr) bool {
+		existing[a.Key] = struct{}{}
+		return true
+	})
+
+	logContext.ForEach(func(key string, value any) {
+		_, found := existing[key]
+		if found {
+			return
 		}
-	}
+		r.AddAttrs(slog.Any(key, value))
+	})
 
 	// info: OpenTelemetryと連携する場合は有効化
 	//// OpenTelemetry trace情報を追加

--- a/internal/common/logger/custom.go
+++ b/internal/common/logger/custom.go
@@ -15,7 +15,7 @@ func NewCustomLogHandler(handler slog.Handler) *CustomLogHandler {
 	}
 }
 
-// Handle contextにセットされたLogContextからログ出力フィールドを追加する
+// Handle contextにセットされたLogContextからログ出力属性を追加する
 func (h *CustomLogHandler) Handle(ctx context.Context, r slog.Record) error { //nolint:gocritic // slogのinterface仕様なので第2引数はポインタ型にできない
 	logContext, ok := LogContextFromContext(ctx)
 	if !ok {

--- a/internal/presentation/middleware/log.go
+++ b/internal/presentation/middleware/log.go
@@ -33,7 +33,7 @@ func Log() gin.HandlerFunc {
 
 		c.Next()
 
-		// アクセスログを出力（log_typeはcall-siteで明示することでLogContextより優先される）
+		// アクセスログを出力
 		slog.InfoContext(ctx, "access log",
 			slog.Any("log_type", logger.LogTypeAccess),
 			slog.String("host", c.Request.Host),

--- a/internal/presentation/middleware/log.go
+++ b/internal/presentation/middleware/log.go
@@ -21,21 +21,21 @@ func Log() gin.HandlerFunc {
 		c.Header(HttpHeaderXRequestID, requestID)
 
 		// LogContextの設定
-		logContextMap := logger.NewLogContextMap()
-		logContextMap.Store("log_type", logger.LogTypeApp)
-		logContextMap.Store("request_id", requestID)
-		logContextMap.Store("method", c.Request.Method)
-		logContextMap.Store("path", c.Request.URL.Path)
+		logContext := logger.NewLogContext()
+		logContext.Set("log_type", logger.LogTypeApp)
+		logContext.Set("request_id", requestID)
+		logContext.Set("method", c.Request.Method)
+		logContext.Set("path", c.Request.URL.Path)
 
-		// contextにlogContextMapをセット
-		ctx := logger.WithLogContextMap(c.Request.Context(), logContextMap)
+		// contextにlogContextをセット
+		ctx := logger.WithLogContext(c.Request.Context(), logContext)
 		c.Request = c.Request.WithContext(ctx)
 
 		c.Next()
 
-		// アクセスログを出力
-		logger.ChangeLogType(ctx, logger.LogTypeAccess)
+		// アクセスログを出力（log_typeはcall-siteで明示することでLogContextより優先される）
 		slog.InfoContext(ctx, "access log",
+			slog.Any("log_type", logger.LogTypeAccess),
 			slog.String("host", c.Request.Host),
 			slog.String("uri", c.Request.URL.RequestURI()),
 			slog.Int("status", c.Writer.Status()),


### PR DESCRIPTION
## Summary
- `LogContextMap` (sync.Map) を `LogContext` (sync.RWMutex内包struct) に再設計
- log_type 切替の方式を変更: middlewareで mid-request mutateする方式から、呼び出し元の明示attrが優先される方式へ
- 業務コードから動的に属性追加するヘルパー `SetLogContextAttribute` を追加
- LogType関連の定数を `constant.go` に分離

## 背景
従来の実装は `ChangeLogType` で middleware がリクエスト処理中に LogContext を書き換える方式だった。これだと、ハンドラ起源の goroutine が `c.Next()` を超えて生き残った場合に、書き換え後の値（`log_type=access_log`）を後追いログが拾ってしまい、app_log が access_log として出力される汚染リスクがあった。

## 設計
- `LogContext`: `sync.RWMutex` + `map[string]any` を内包する struct。`Set` / `ForEach` メソッドを公開
- `CustomLogHandler.Handle`: 呼び出し元で既にセット済みのキーは LogContext から追加しない（呼び出し元の値が LogContext より優先）
- middleware:
  - 初期化時に `log_type=app_log` を LogContext に Set
  - アクセスログ出力時は `slog.Any(\"log_type\", LogTypeAccess)` を call-site で明示することで、出力 JSON では access_log が勝つ
  - LogContext を mid-request で書き換えない → 後追い goroutine の汚染を構造的に防ぐ
- `SetLogContextAttribute(ctx, key, value)`: 業務コードから ctx の LogContext に属性追加できるヘルパー（user_id 等の動的フィールドを想定）

## Test plan
- [x] go build ./... pass
- [x] go vet ./... pass
- [x] 開発サーバーで正常系 (`GET /v1/articles`) を実行し、access_log 1行に \`log_type=access_log\` が1つだけ含まれることを確認
- [x] 異常系で app_log と access_log が同一 request_id で出力されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * ログコンテキスト管理機構を改善し、スレッドセーフ性とパフォーマンスを向上させました。アクセスログの処理フローを最適化し、より明示的な属性管理を実現しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kageyamountain/kageyamountain.net-backend/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->